### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you have a key for jwplayer just include it as you normally would according t
 
 Add any jwplayer setup options you want to an object in your angular controller.
 ```js
-angular.module('myApp').controller('HomeCtrl', ['$scope', function($scope) {
+angular.module('myApp',['angular-jwplayer']).controller('HomeCtrl', ['$scope', function($scope) {
 
 	$scope.options = {
 		file: "pathToMyVideo/myvideo.mp4",


### PR DESCRIPTION
The generic myApp is a module different than the module at which angular-jwplayer directive resides. So, the generic module needs that dependency injected. Without it, it doesn't work.
